### PR TITLE
Update find-domains command to prevent skipping first 500 redirects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,11 @@ notifications:
     on_failure: change
 
 php:
-  - 5.3
   - 5.6
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-
-matrix:
-  include:
-    - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ notifications:
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -11,7 +11,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 		global $wpdb;
 
 		$posts_per_page = 500;
-		$paged = 1;
+		$paged = 0;
 
 		$domains = array();
 

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://vip.wordpress.com/plugins/wpcom-legacy-redirector/
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.2.0
+ * Requires PHP: 5.6
  * Author: Automattic / WordPress.com VIP
  * Author URI: https://vip.wordpress.com
  *


### PR DESCRIPTION
The query that populates `$redirect_urls` is set with an initial offset of 500.

Updating `$paged` with an initial value of 0 will set the query's offset to begin at 0.