### PR TITLE
Add verify-redirects command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,11 @@ notifications:
     on_failure: change
 
 php:
-  - 5.3
   - 5.6
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-
-matrix:
-  include:
-    - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ notifications:
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -225,9 +225,9 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			'update_status' => array(),
 			'query_count'   => array(),
 			'query_count'   => 0,
-			'offset'        => '',
+			'offset'        => 0,
 		);
-		$posts_per_page = 100;
+		$posts_per_page = 500;
 		$paged = 0;
 
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -205,14 +205,18 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 	 * [--verbose]
 	 * : Print notifications to the console for passing URLs.
 	 *
+	 * [--force_ssl]
+	 * : Forces verification over SSL to utilize HTTP/2 multiplexing.
+	 *
 	 * ## EXAMPLES
 	 *
 	 * wp wpcom-legacy-redirector verify-redirects
 	 *
 	 * @subcommand verify-redirects
-	 * @synopsis [--status=<status>] [--format=<format>] [--verbose]
+	 * @synopsis [--status=<status>] [--format=<format>] [--verbose] [--force_ssl]
 	 */
 	function verify_redirects( $args, $assoc_args ) {
+
 		global $wpdb;
 		$post_types = get_post_types( array( 'public' => true ) );
 
@@ -276,7 +280,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			}
 
 			// Validate and format redirects for verification.
-			$validated_redirects    = WPCOM_Legacy_Redirector::validate_redirects( $redirects_to_verify, $notices, $update_redirect_status, $query_count, $progress );
+			$validated_redirects    = WPCOM_Legacy_Redirector::validate_redirects( $redirects_to_verify, $notices, $update_redirect_status, $query_count, $progress, $assoc_args['force_ssl'] );
 
 			if ( is_wp_error( $validated_redirects ) ) {
 				WP_CLI::error( $validated_redirects->get_error_message() );

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -459,7 +459,6 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			foreach ( $update_redirect_status as $status => $redirects_to_update ) {
 				foreach ( $redirects_to_update as $redirect_to_update ) {
 					$wpdb->update( $wpdb->posts, array( 'post_status' => $status ), array( 'ID' => $redirect_to_update ) );
-					clean_post_cache( $redirect_to_update );
 				}
 			}
 		}

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -204,12 +204,15 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 	 * [--verbose]
 	 * : Print notifications to the console for passing URLs.
 	 *
+	 * [--strict]
+	 * : Enable verification for validated redirects to post ids.
+	 *
 	 * ## EXAMPLES
 	 *
 	 * wp wpcom-legacy-redirector verify-redirects
 	 *
 	 * @subcommand verify-redirects
-	 * @synopsis [--status=<status>] [--format=<format>] [--verbose]
+	 * @synopsis [--status=<status>] [--format=<format>] [--verbose] [--strict]
 	 */
 	function verify_redirects( $args, $assoc_args ) {
 
@@ -355,6 +358,14 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 						);
 						if ( 'draft' !== $redirect->poststatus ) {
 							$update_redirect_status['draft'][] = $redirect->ID;
+						}
+						continue;
+					}
+
+					// Don't verify urls to validated post ids unless the [--strict] flag is explicitly set.
+					if ( ! $assoc_args['strict'] ) {
+						if ( 'publish' !== $redirect->poststatus ) {
+							$update_redirect_status['publish'][] = $redirect->ID;
 						}
 						continue;
 					}

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -245,7 +245,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 
 		$total_redirects = $wpdb->get_var( "SELECT COUNT( ID ) FROM $wpdb->posts WHERE " . $total_redirects_where );
 
-		$progress = \WP_CLI\Utils\make_progress_bar( 'Verifying ' . $total_redirects . ' redirects', (int) $total_redirects );
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Verifying ' . number_format( $total_redirects ) . ' redirects', (int) $total_redirects );
 
 		do {
 
@@ -339,7 +339,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 						'id'        => $redirect['id'],
 						'from_url'  => $redirect['from']['path'],
 						'to_url'    => $redirect['to']['raw'],
-						'message'   => implode( "\n", $redirect_head->get_error_messages() ),
+						'message'   => implode( PHP_EOL, $redirect_head->get_error_messages() ),
 					);
 					continue;
 				}
@@ -369,7 +369,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 					}
 					continue;
 				}
-			} // End foreach().
+			}
 
 			// Update redirect status
 			if ( count( $update_redirect_status ) > 0 ) {

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -376,8 +376,11 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 				foreach ( $update_redirect_status as $redirect_status => $redirects_to_update ) {
 					foreach ( $redirects_to_update as $redirect_to_update ) {
 						$updated_rows = $wpdb->update( $wpdb->posts, array( 'post_status' => $redirect_status ), array( 'ID' => $redirect_to_update ) );
-						if ( $updated_rows && $redirect_status !== $status ) {
-							$offset = $offset + $updated_rows;
+						if ( $updated_rows ) {
+							clean_post_cache( $updated_rows );
+							if ( $redirect_status !== $status ) {
+								$offset = $offset + $updated_rows;
+							}
 						}
 					}
 				}

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -199,6 +199,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 	 *   - json
 	 *   - yaml
 	 *   - csv
+	 *   - file
 	 * ---
 	 *
 	 * [--verbose]
@@ -314,7 +315,13 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 		$progress->finish();
 
 		if ( count( $notices ) > 0 ) {
-			WP_CLI\Utils\format_items( $format, $notices, array( 'id', 'from_url', 'to_url', 'message' ) );
+			if ( 'file' === $format ) {
+				$fp = fopen( 'wpcom-legacy-redirector_verify-redirects_' . time() . '.csv', 'w');
+				WP_CLI\Utils\write_csv( $fp, $notices, array( 'id', 'from_url', 'to_url', 'message' ) );
+				fclose($fp);
+			} else {
+				WP_CLI\Utils\format_items( $format, $notices, array( 'id', 'from_url', 'to_url', 'message' ) );
+			}
 		} else {
 			echo WP_CLI::colorize( "%GAll of your redirects have been verified. Nice work!%n " );
 		}

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -444,13 +444,14 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 		} while ( count( $redirects ) );
 
 		// Update redirect status
-		foreach ( $update_redirect_status as $status => $redirects_to_update ) {
-			foreach ( $redirects_to_update as $redirect_to_update ) {
-				$wpdb->update( $wpdb->posts, array( 'post_status' => $status ), array( 'ID' => $redirect_to_update ) );
-				clean_post_cache( $redirect_to_update );
+		if ( count( $update_redirect_status ) > 0 ) {
+			foreach ( $update_redirect_status as $status => $redirects_to_update ) {
+				foreach ( $redirects_to_update as $redirect_to_update ) {
+					$wpdb->update( $wpdb->posts, array( 'post_status' => $status ), array( 'ID' => $redirect_to_update ) );
+					clean_post_cache( $redirect_to_update );
+				}
 			}
 		}
-
 
 		$progress->finish();
 

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -271,7 +271,8 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 
 			foreach ( $redirect_urls as $redirect_url ) {
 
-				$from_url = home_url( $redirect_url->post_title );
+				$from_path = $redirect_url->post_title;
+				$from_url = home_url( $from_path );
 
 				if ( ! empty( $redirect_url->post_excerpt ) ) {
 					$to_url = $redirect_url->post_excerpt;
@@ -279,7 +280,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 					if ( ! wp_validate_redirect( $to_url, false ) ) {
 						$notices[] = array(
 							'id'        => $redirect_url->ID,
-							'from_url'  => $from_url,
+							'from_url'  => $from_path,
 							'to_url'    => $to_url,
 							'message'   => 'failed wp_validate_redirect()',
 						);
@@ -291,7 +292,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 					if ( ! $parent instanceof WP_Post ) {
 						$notices[] = array(
 							'id'        => $redirect_url->ID,
-							'from_url'  => $from_url,
+							'from_url'  => $from_path,
 							'to_url'    => $redirect_url->post_parent,
 							'message'   => 'Redirecting to a post id that is not an instance of WP_Post.',
 						);
@@ -301,7 +302,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 					if ( 'publish' !== $parent->post_status ) {
 						$notices[] = array(
 							'id'        => $redirect_url->ID,
-							'from_url'  => $from_url,
+							'from_url'  => $from_path,
 							'to_url'    => $redirect_url->post_parent,
 							'message'   => 'Attempting to redirect to an unpublished post.',
 						);
@@ -321,7 +322,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 						if ( $assoc_args['verbose'] ) {
 							$notices[] = array(
 								'id'        => $redirect_url->ID,
-								'from_url'  => $from_url,
+								'from_url'  => $from_path,
 								'to_url'    => $to_url,
 								'message'   => 'Verified',
 							);
@@ -330,7 +331,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 					} else {
 						$notices[] = array(
 							'id'        => $redirect_url->ID,
-							'from_url'  => $from_url,
+							'from_url'  => $from_path,
 							'to_url'    => $to_url,
 							'message'   => 'Mismatch: redirected to ' . $resulting_url,
 						);
@@ -339,14 +340,14 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 				} elseif ( 2 == substr( $status, 0, 1 ) ) {
 					$notices[] = array(
 						'id'        => $redirect_url->ID,
-						'from_url'  => $from_url,
+						'from_url'  => $from_path,
 						'to_url'    => $to_url,
 						'message'   => 'Did not redirect - returned ' . $status,
 					);
 				} else {
 					$notices[] = array(
 						'id'        => $redirect_url->ID,
-						'from_url'  => $from_url,
+						'from_url'  => $from_path,
 						'to_url'    => $to_url,
 						'message'   => $status . ' ' . $status_message,
 					);

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -279,6 +279,7 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 					),
 					'redirect' => array(
 						'status' => 200,
+						'count' => 1,
 						'resulting_url' => 'http://google.com/',
 					),
 				),
@@ -294,6 +295,7 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 					),
 					'redirect' => array(
 						'status' => 200,
+						'count' => 1,
 						'resulting_url' => '/post1',
 					),
 				),

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -300,6 +300,38 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 					),
 				),
 			),
+			'too_many_redirects' => array(
+				'redirect' => array(
+					'from' => array(
+						'raw' => '1',
+						'formatted' => '/post1',
+					),
+					'to' => array(
+						'formatted' => '/redirect_location',
+					),
+					'redirect' => array(
+						'status' => 200,
+						'count' => 2,
+						'resulting_url' => '/somewhere_else',
+					),
+				),
+			),
+			'redirect_to_404' => array(
+				'redirect' => array(
+					'from' => array(
+						'raw' => '1',
+						'formatted' => '/post1',
+					),
+					'to' => array(
+						'formatted' => '/somewhere_else',
+					),
+					'redirect' => array(
+						'status' => 404,
+						'count' => 1,
+						'resulting_url' => '/somewhere_else',
+					),
+				),
+			),
 		);
 	}
 
@@ -326,6 +358,7 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 					),
 					'redirect' => array(
 						'status' => 200,
+						'count' => 1,
 						'resulting_url' => 'http://google.com',
 					),
 				),

--- a/tests/test-redirects.php
+++ b/tests/test-redirects.php
@@ -117,5 +117,23 @@ class WpcomLegacyRedirectsTest extends WP_UnitTestCase {
 		$this->assertEquals( $redirect, $protected_to, 'get_redirect_uri failed' );
 	}
 
-}
+	function test_validate_url_redirect() {
+		// try redirecting to bad host
+		// try adding a host and then redirecting to it
+	}
 
+	function test_validate_post_redirect() {
+		// Redirect to an attachment type (status = inherit) (success)
+		// Redirect to a published parent (fail)
+		// Redirect to private post type (fail)
+	}
+
+	function test_verify_redirect() {
+		// pass correct redirect (pass)
+
+		// Fails:
+		// pass redirect that adds trailing slash
+		// pass redirect with non 200 status
+		// pass mismatching redirect
+	}
+}

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -315,7 +315,7 @@ class WPCOM_Legacy_Redirector {
 	 * @param array $post_types Array of publicly accessible post types.
 	 * @return bool|WP_Error True on success, false or WP_Error on failure.
 	 */
-	private static function validate_url_redirect( $redirect, $post_types ) {
+	static function validate_url_redirect( $redirect, $post_types ) {
 
 		// Validate non-relative URLs.
 		if (
@@ -336,7 +336,7 @@ class WPCOM_Legacy_Redirector {
 	 *
 	 * @return bool|WP_Error True on success, false or WP_Error on failure.
 	 */
-	private static function validate_post_redirect( $redirect, $post_types ) {
+	static function validate_post_redirect( $redirect, $post_types ) {
 
 		if ( $redirect['parent']['id'] <= 0 ) {
 			return new WP_Error( 'no-parent-post', 'Attempting to redirect to a nonexistent post id.' );
@@ -497,7 +497,7 @@ class WPCOM_Legacy_Redirector {
 	 * @param array $redirect Array of redirects.
 	 * @return bool|WP_Error True if the redirect works as expected, otherwise WP_Error.
 	 */
-	private static function verify_redirect_status( $redirect ) {
+	static function verify_redirect_status( $redirect ) {
 
 		if (
 			! isset( $redirect['to']['formatted'] )

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -367,7 +367,17 @@ class WPCOM_Legacy_Redirector {
 	 * @return array|WP_Error Array of notices for failed redirects and redirects to update the status on - or WP_Error on failure.
 	 */
 	static function verify_redirects(  $redirects_to_verify, $notices, $update_redirect_status, $progress, $verbose = false ) {
-		$redirects = self::try_redirects( $redirects_to_verify, $progress );
+		if ( version_compare( PHP_VERSION, '7.0.7' ) >= 0 ) {
+			$redirects = self::try_redirects( $redirects_to_verify, $progress );
+		} else {
+			// If PHP < 7.0.7, we need to manually limit the # of connections.
+			$redirects = array();
+			$redirects_to_verify = array_chunk( $redirects_to_verify, 10 );
+			foreach ( $redirects_to_verify as $redirects_chunk ) {
+				$redirects[] = self::try_redirects( $redirects_to_verify, $progress );
+				sleep( 1 );
+			}
+		}
 
 		foreach ( $redirects as $key => $redirect ) {
 

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -206,9 +206,10 @@ class WPCOM_Legacy_Redirector {
 	 * @param array $update_redirect_status Array of redirects that need an updated status.
 	 * @param int $query_count Number of queries run in this operation.
 	 * @param obj $progress WP-CLI progress bar.
+	 * @param bool $force_ssl Whether to format URLs using SSL.
 	 * @return array|WP_Error Array of validated redirects, notices of failed redirects, and redirects to update the status on - or WP_Error on failure.
 	 */
-	static function validate_redirects( $redirects, $notices, $update_redirect_status, $query_count, $progress ) {
+	static function validate_redirects( $redirects, $notices, $update_redirect_status, $query_count, $progress, $force_ssl = false ) {
 
 		if ( ! is_array( $redirects ) ) {
 			return new WP_Error( 'no-redirects', 'No redirects to validate.' );
@@ -238,7 +239,11 @@ class WPCOM_Legacy_Redirector {
 
 			// Format relative from urls
 			if ( '/' == substr( $redirect['from']['raw'], 0, 1 ) ) {
-				$redirect['from']['formatted'] = home_url( $redirect['from']['raw'] );
+				if ( $force_ssl ) {
+					$redirect['from']['formatted'] = home_url( $redirect['from']['raw'], 'https' );
+				} else {
+					$redirect['from']['formatted'] = home_url( $redirect['from']['raw'] );
+				}
 			}
 
 			// Format and validate, based on redirect destination type.
@@ -248,7 +253,11 @@ class WPCOM_Legacy_Redirector {
 
 				// Format relative to URLs
 				if ( '/' == substr( $redirect['to']['raw'], 0, 1 ) ) {
-					$redirect['to']['formatted'] = home_url( $redirect['to']['raw'] );
+					if ( $force_ssl ) {
+						$redirect['to']['formatted'] = home_url( $redirect['to']['raw'], 'https' );
+					} else {
+						$redirect['to']['formatted'] = home_url( $redirect['to']['raw'] );
+					}
 				}
 
 				$validation = self::validate_url_redirect( $redirect, $post_types );

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://vip.wordpress.com/plugins/wpcom-legacy-redirector/
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.2.0
+ * Requires PHP: 5.6
  * Author: Automattic / WordPress.com VIP
  * Author URI: https://vip.wordpress.com
  *

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -475,7 +475,7 @@ class WPCOM_Legacy_Redirector {
 
 		foreach ( array_keys( $ch ) as $key ) {
 			$redirects[ $key ]['redirect']['status']           = curl_getinfo( $ch[ $key ], CURLINFO_HTTP_CODE );
-			$redirects[ $key ]['redirect']['count']            = curl_getinfo( $ch[ $key ], CURLINFO_REDIRECT_COUNT ); // @TODO not currently using this.
+			$redirects[ $key ]['redirect']['count']            = curl_getinfo( $ch[ $key ], CURLINFO_REDIRECT_COUNT );
 			$redirects[ $key ]['redirect']['resulting_url']    = curl_getinfo( $ch[ $key ], CURLINFO_EFFECTIVE_URL );
 			curl_multi_remove_handle( $mh, $ch[ $key ] );
 		}
@@ -517,10 +517,13 @@ class WPCOM_Legacy_Redirector {
 			return new WP_Error( 'missing-trailing-slash', 'Warning: Redirect works, but missing trailing slash.' );
 
 		} elseif ( 200 !== $redirect['redirect']['status'] ) {
-			return new WP_Error( 'http-error-code', 'Returned' . $redirect['redirect']['status'] );
+			return new WP_Error( 'http-error-code', sprintf( 'Returned %s', $redirect['redirect']['status'] ) );
+
+		} elseif ( 1 < $redirect['redirect']['count'] ) {
+			return new WP_Error( 'http-error-code', sprintf( 'Mismatch: Redirected %d times, ending at %s', number_format( $redirect['redirect']['count'] ), $redirect['redirect']['resulting_url'] ) );
 
 		} else {
-			return new WP_Error( 'redirect-mismatch', 'Mismatch: redirected to ' . $redirect['redirect']['resulting_url'] );
+			return new WP_Error( 'redirect-mismatch', sprintf( 'Mismatch: redirected to %s', $redirect['redirect']['resulting_url'] ) );
 		}
 	}
 
@@ -567,7 +570,7 @@ class WPCOM_Legacy_Redirector {
 			$update_status[ $status ][] = $formatted_redirect['id'];
 		}
 
-		return $redirects;
+		return $update_status;
 	}
 
 

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -201,7 +201,7 @@ class WPCOM_Legacy_Redirector {
 
 		} else {
 
-			if ( ! $redirect['parent']['id'] > 0 ) {
+			if ( $redirect['parent']['id'] <= 0 ) {
 				return array(
 					'id'        => $redirect['id'],
 					'from_url'  => $redirect['from']['path'],
@@ -230,7 +230,7 @@ class WPCOM_Legacy_Redirector {
 					'message'   => 'Attempting to redirect to a private post type: ' . $redirect['parent']['post_type'],
 				);
 			}
-		} // End if().
+		}
 
 		return true;
 	}
@@ -275,7 +275,7 @@ class WPCOM_Legacy_Redirector {
 				'to_url'    => $redirect['to']['raw'],
 				'message'   => $redirect['redirect']['status'] . ' ' . $redirect['redirect']['status_msg'],
 			);
-		} // End if().
+		}
 	}
 
 	private static function get_url_hash( $url ) {

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -249,6 +249,7 @@ class WPCOM_Legacy_Redirector {
 			if ( ! empty( $redirect->post_excerpt ) ) {
 				$formatted_redirect['destination_type'] = 'url';
 				$formatted_redirect['to']['raw'] = $redirect->post_excerpt;
+				$formatted_redirect['to']['formatted'] = $redirect->post_excerpt;
 
 				// Format relative to URLs
 				if ( '/' == substr( $formatted_redirect['to']['raw'], 0, 1 ) ) {

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -508,20 +508,23 @@ class WPCOM_Legacy_Redirector {
 			return new WP_Error( 'redirect-missing-information', 'Redirect is missing information and cannot be validated.' );
 		}
 
-		if ( $redirect['to']['formatted'] === $redirect['redirect']['resulting_url'] ) {
-			return true;
-
-		} elseif ( $redirect['from']['formatted'] === $redirect['redirect']['resulting_url'] ) {
+		if ( $redirect['from']['formatted'] === $redirect['redirect']['resulting_url'] ) {
 			return new WP_Error( 'did-not-redirect', 'Did not redirect.' );
 
 		} elseif ( $redirect['from']['formatted'] . '/' === $redirect['redirect']['resulting_url'] ) {
 			return new WP_Error( 'missing-trailing-slash', 'Warning: Redirect works, but missing trailing slash.' );
+
+		} elseif ( 404 === $redirect['redirect']['status'] ) {
+			return new WP_Error( 'http-error-code', 'Redirected to 404 page.' );
 
 		} elseif ( 200 !== $redirect['redirect']['status'] ) {
 			return new WP_Error( 'http-error-code', sprintf( 'Returned %s', $redirect['redirect']['status'] ) );
 
 		} elseif ( 1 < $redirect['redirect']['count'] ) {
 			return new WP_Error( 'http-error-code', sprintf( 'Mismatch: Redirected %d times, ending at %s', number_format( $redirect['redirect']['count'] ), $redirect['redirect']['resulting_url'] ) );
+
+		} elseif ( $redirect['to']['formatted'] === $redirect['redirect']['resulting_url'] ) {
+			return true;
 
 		} else {
 			return new WP_Error( 'redirect-mismatch', sprintf( 'Mismatch: redirected to %s', $redirect['redirect']['resulting_url'] ) );

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -426,7 +426,7 @@ class WPCOM_Legacy_Redirector {
 
 		// CURLMOPT_MAX_TOTAL_CONNECTIONS was added in PHP 7.0.7, which is needed to limit concurrent connections.
 		if ( version_compare( PHP_VERSION, '7.0.7' ) >= 0 ) {
-			curl_multi_setopt( $mh, CURLMOPT_MAX_TOTAL_CONNECTIONS, 100 );                      // max simultaneous open connections - see https://curl.haxx.se/libcurl/c/CURLMOPT_MAX_TOTAL_CONNECTIONS.html
+			curl_multi_setopt( $mh, CURLMOPT_MAX_TOTAL_CONNECTIONS, 10 );                      // max simultaneous open connections - see https://curl.haxx.se/libcurl/c/CURLMOPT_MAX_TOTAL_CONNECTIONS.html
 			curl_multi_setopt( $mh, CURLMOPT_PIPELINING, CURLPIPE_HTTP1 | CURLPIPE_MULTIPLEX ); // try HTTP/1 pipelining and HTTP/2 multiplexing - see https://curl.haxx.se/libcurl/c/CURLMOPT_PIPELINING.html
 		} else {
 			curl_multi_setopt( $mh, CURLMOPT_PIPELINING, CURLPIPE_HTTP1 );


### PR DESCRIPTION
Resolves #13

This command verifies the redirects are working properly, and marks them as published (to denote they have been verified).

### What we're checking for (in plain english)

1. If redirecting to a URL:
	- Does the URL pass `wp_validate_redirect()`, which checks for a valid url and an allowed host to redirect to.

2. If redirecting to a post id:
	- Does the post we're redirecting to exist?
	- Is the post we're redirecting to published?
	- Are we redirecting to a post type that is not publicly accessible?

3. If we haven't failed validation yet:
	- Test the redirect

	- Is the redirect a 300 level status code?
		- If the redirect matches our destination URL, then mark the redirect as published (verified)
		- Did we redirect to the same page, but with a trailing slash?
		- If we reach this point, the redirect failed.

	- Is the redirect a 200 level status code?
		- If we reach this point, the redirect never ran. The from URL must not be a 404.

	- Is it a different status code? (not 200 or 300 level)
		- Something bad happened, report the status code.

### Performance features & notes

* We're querying for 500 redirect entries at a time, sleeping for 1 second every 100 rows processed.
* The main query uses a left join on the same table to capture post parent info that allows us to run all the checks in section 2 without calling `get_post()`. 
This allows us to fail early if there's a problem before we need to call `get_post()` (the most expensive query we're using).
* The query fetches rows ordered by post_parent, so multiple redirects to the same post are verified one after another. I've added code that will reuse the post object in scenarios like this, cutting down on unnecessary calls.

The most expensive verification will be redirects to post ids that pass verification and need to be marked as published (verified). Failure notices should be optimized to happen as quickly and efficiently as possible.

### Testing Instructions

* Setup a blank site on your localhost of choice
* run the following commands in terminal:
	* `wp plugin install wordpress-importer --activate`
	* `wp import --prompt`
		* download a copy of the file from https://wpcom-themes.svn.automattic.com/demo/theme-unit-test-data.xml
		* --author=create
* Using the following codeblock, make a csv file and import it into the site:
```
/redirect-to-non-url,this-isnt-a-url
/redirect-to-a-bad-url,/lot$-0f-+_)(*&^%$#!—Junk
/redirect-to-a-non-whitelisted-host,https://google.com
/redirect-to-autodraft,3
/redirect-to-scheduled-post,1153
/redirect-to-attachment,1692
/redirect-to-published-post,993
/redirect-to-published-page,735
notaurl-redirecting-topublishedpage/735
/lot$-0f-+_)(*&^%$#!—Junk/735
/post-id-that-doesnt-exist/20000
/sample-page/,/anywhere
/sample-page,this-should-redirect-to-include-trailing-slash
```
* in terminal, run `wp wpcom-legacy-redirector verify-redirects --format=table`