### PR TITLE
Improve notices on import commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,11 @@ notifications:
     on_failure: change
 
 php:
-  - 5.3
   - 5.6
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-
-matrix:
-  include:
-    - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ notifications:
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -175,7 +175,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			}
 			$progress->finish();
 			$offset += 1000;
-		} while( $redirects && $offset < $end_offset );
+		} while( $total > 1000 && $offset < $end_offset );
 
 		if ( count( $notices ) > 0 ) {
 			WP_CLI\Utils\format_items( $format, $notices, array( 'redirect_from', 'redirect_to', 'message' ) );

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -139,6 +139,10 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			)
 		);
 
+		if ( 0 === absint( $total_redirects ) ) {
+			WP_CLI::error( "No redirects found for that meta_key." );
+		}
+
 		$progress = \WP_CLI\Utils\make_progress_bar( sprintf( 'Importing %s redirects', $total_redirects ), $total_redirects );
 
 		do {

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -197,15 +197,16 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 	function import_from_csv( $args, $assoc_args ) {
 		define( 'WP_IMPORTING', true );
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
+		$csv = trim( \WP_CLI\Utils\get_flag_value( $assoc_args, 'csv' ) );
 		$notices = array();
 
-		if ( empty( $assoc_args['csv'] ) || ! file_exists( $assoc_args['csv'] ) ) {
+		if ( empty( $csv ) || ! file_exists( $csv ) ) {
 			WP_CLI::error( "Invalid 'csv' file" );
 		}
 
 		global $wpdb;
 		$row = 0;
-		if ( ( $handle = fopen( $assoc_args['csv'], "r" ) ) !== FALSE ) {
+		if ( ( $handle = fopen( $csv, "r" ) ) !== FALSE ) {
 			while ( ( $data = fgetcsv( $handle, 2000, "," ) ) !== FALSE ) {
 				$row++;
 				$redirect_from = $data[ 0 ];

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -109,6 +109,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 	 * [--dry_run]
 	 *
 	 * [--verbose]
+	 * : Display notices for sucessful imports and duplicates (if skip_dupes is used)
  	 *
  	 * @subcommand import-from-meta
 	 * @synopsis --meta_key=<name-of-meta-key> [--start=<start-offset>] [--end=<end-offset>] [--skip_dupes=<skip-dupes>] [--format=<format>] [--dry_run] [--verbose]

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -78,7 +78,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 		$inserted = WPCOM_Legacy_Redirector::insert_legacy_redirect( $from_url, $to_url );
 
 		if ( ! $inserted || is_wp_error( $inserted ) ) {
-			WP_CLI::warning( sprintf( "Couldn't insert %s -> %s", $from_url, $to_url ) );
+			WP_CLI::error( sprintf( "Couldn't insert %s -> %s", $from_url, $to_url ) );
 		}
 
 		WP_CLI::success( sprintf( "Inserted %s -> %s", $from_url, $to_url ) );

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -141,10 +141,10 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 		);
 
 		if ( 0 === absint( $total_redirects ) ) {
-			WP_CLI::error( "No redirects found for that meta_key." );
+			WP_CLI::error( sprintf( 'No redirects found for meta_key: %s', $meta_key ) );
 		}
 
-		$progress = \WP_CLI\Utils\make_progress_bar( sprintf( 'Importing %s redirects', $total_redirects ), $total_redirects );
+		$progress = \WP_CLI\Utils\make_progress_bar( sprintf( 'Importing %s redirects', number_format( $total_redirects ) ), $total_redirects );
 
 		do {
 			$redirects = $wpdb->get_results( $wpdb->prepare( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = %s ORDER BY post_id ASC LIMIT %d, 1000", $meta_key, $offset ) );
@@ -160,7 +160,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 						$notices[] = array(
 							'redirect_from' => $redirect->meta_value,
 							'redirect_to'   => $redirect->post_id,
-							'message'       => sprintf( 'Skipped - Redirect for this from URL already exists.', $redirect->meta_value ),
+							'message'       => sprintf( 'Skipped - Redirect for this from URL already exists (%s)', $redirect->meta_value ),
 						);
 					}
 					continue;
@@ -169,7 +169,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 				if ( false === $dry_run ) {
 					$inserted = WPCOM_Legacy_Redirector::insert_legacy_redirect( $redirect->meta_value, $redirect->post_id );
 					if ( ! $inserted || is_wp_error( $inserted ) ) {
-						$failure_message = is_wp_error( $inserted ) ? implode( "\n", $inserted->get_error_messages() ) : 'Could not insert redirect';
+						$failure_message = is_wp_error( $inserted ) ? implode( PHP_EOL, $inserted->get_error_messages() ) : 'Could not insert redirect';
 						$notices[] = array(
 							'redirect_from' => $redirect->meta_value,
 							'redirect_to'   => $redirect->post_id,
@@ -237,7 +237,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 		}
 
 		if ( ! $verbose ) {
-			WP_CLI::line( "Processing..." );
+			WP_CLI::line( 'Processing...' );
 		}
 
 		global $wpdb;
@@ -256,7 +256,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 
 				$inserted = WPCOM_Legacy_Redirector::insert_legacy_redirect( $redirect_from, $redirect_to );
 				if ( ! $inserted || is_wp_error( $inserted ) ) {
-					$failure_message = is_wp_error( $inserted ) ? implode( "\n", $inserted->get_error_messages() ) : 'Could not insert redirect';
+					$failure_message = is_wp_error( $inserted ) ? implode( PHP_EOL, $inserted->get_error_messages() ) : 'Could not insert redirect';
 					$notices[] = array(
 						'redirect_from' => $redirect_from,
 						'redirect_to'   => $redirect_to,

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -154,14 +154,14 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 					if ( ! $inserted || is_wp_error( $inserted ) ) {
 						$failure_message = is_wp_error( $inserted ) ? implode( "\n", $inserted->get_error_messages() ) : 'Could not insert redirect';
 						$notices[] = array(
-							'redirect_from' => $redirect_from,
-							'redirect_to'   => $redirect_to,
+							'redirect_from' => $redirect->meta_value,
+							'redirect_to'   => $redirect->post_id,
 							'message'       => $failure_message,
 						);
 					} elseif ( $verbose ) {
 						$notices[] = array(
-							'redirect_from' => $redirect_from,
-							'redirect_to'   => $redirect_to,
+							'redirect_from' => $redirect->meta_value,
+							'redirect_to'   => $redirect->post_id,
 							'message'       => 'Successfully imported',
 						);
 					}

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -149,14 +149,19 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			$redirects = $wpdb->get_results( $wpdb->prepare( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = %s ORDER BY post_id ASC LIMIT %d, 1000", $meta_key, $offset ) );
 			$i = 0;
 			$total = count( $redirects );
-			WP_CLI::line( "Found $total entries" );
 
 			foreach ( $redirects as $redirect ) {
 				$i++;
 				$progress->tick();
 
 				if ( true === $skip_dupes && 0 !== WPCOM_Legacy_Redirector::get_redirect_post_id( parse_url( $redirect->meta_value, PHP_URL_PATH ) ) ) {
-					WP_CLI::line( "Redirect for {$redirect->post_id} from {$redirect->meta_value} already exists. Skipping" );
+					if ( $verbose ) {
+						$notices[] = array(
+							'redirect_from' => $redirect->meta_value,
+							'redirect_to'   => $redirect->post_id,
+							'message'       => sprintf( 'Skipped - Redirect for this from URL already exists.', $redirect->meta_value ),
+						);
+					}
 					continue;
 				}
 

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://vip.wordpress.com/plugins/wpcom-legacy-redirector/
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.2.0
+ * Requires PHP: 5.6
  * Author: Automattic / WordPress.com VIP
  * Author URI: https://vip.wordpress.com
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Using the `insert-redirect` command, if a redirect fails insert, use a WP_CLI::error() to halt the command, vs. existing warning() that results in an additional success message.
* Add `[--format=<format>]` and `[--verbose]` params to the import commands (with documentation)
* Add a progress bar to the `import-from-meta` command, and update the `import-from-csv` command to cut down on default notifications. I chose not to implement a progress bar on the csv command, because of the additional overhead it would take to calculate total rows in the csv file.
* Display an error message if no redirects are found with the meta_key supplied to the `import-from-meta` command.

cc @mjangda 
