### PR TITLE
Drop PHP 5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,11 @@ notifications:
     on_failure: change
 
 php:
-  - 5.3
   - 5.6
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-
-matrix:
-  include:
-    - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ notifications:
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://vip.wordpress.com/plugins/wpcom-legacy-redirector/
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.2.0
+ * Requires PHP: 5.6
  * Author: Automattic / WordPress.com VIP
  * Author URI: https://vip.wordpress.com
  *


### PR DESCRIPTION
This is an alternative to https://github.com/Automattic/WPCOM-Legacy-Redirector/pull/27, dropping support for PHP 5.3 and simplifying the travis config file.

cc @mjangda 