### PR TITLE
Refactor: Extract some code into separate classes.

### DIFF
--- a/includes/class-capability.php
+++ b/includes/class-capability.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Automattic\LegacyRedirector;
+
+final class Capability {
+	const MANAGE_REDIRECTS_CAPABILITY = 'manage_redirects';
+
+	/**
+	 * Add custom capability onto some existing roles using VIP Helpers with fallbacks.
+	 */
+	public function register() {
+		if ( function_exists( 'wpcom_vip_add_role_caps' ) ) {
+			wpcom_vip_add_role_caps( 'administrator', self::MANAGE_REDIRECTS_CAPABILITY );
+			wpcom_vip_add_role_caps( 'editor', self::MANAGE_REDIRECTS_CAPABILITY );
+		} else {
+			$roles = array( 'administrator', 'editor' );
+			foreach ( $roles as $role ) {
+				$role_obj = get_role( $role );
+				$role_obj->add_cap( self::MANAGE_REDIRECTS_CAPABILITY );
+			}
+		}
+	}
+}

--- a/includes/class-list-redirects.php
+++ b/includes/class-list-redirects.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Automattic\LegacyRedirector;
+
+final class List_Redirects {
+	
+	public function init() {
+		add_filter( 'manage_vip-legacy-redirect_posts_columns', array( $this, 'set_columns' ) );
+		add_action( 'manage_vip-legacy-redirect_posts_custom_column', array( $this, 'posts_custom_column' ), 10, 2 );
+		add_filter( 'post_row_actions', array( $this, 'modify_list_row_actions' ), 10, 2 );
+	}
+
+	/**
+	 * Set Columns for Redirect Table.
+	 *
+	 * @param array $columns Columns to show for the post type.
+	 */
+	public function set_columns( $columns ) {
+		return array(
+			'cb'   => '<input type="checkbox" />',
+			'from' => __( 'Redirect From' ),
+			'to'   => __( 'Redirect To' ),
+			'date' => __( 'Date' ),
+		);
+	}
+
+	/**
+	 * Add the data to the custom columns for the vip-legacy-redirects post type.
+	 * Provide warnings for possibly bad redirects.
+	 *
+	 * @param string $column  The Column for the post_type table.
+	 * @param int    $post_id The Post ID.
+	 */
+	public function posts_custom_column( $column, $post_id ) {
+		switch ( $column ) {
+			case 'from':
+				echo esc_html( get_the_title( $post_id ) );
+				break;
+			case 'to':
+				$post    = get_post( $post_id );
+				$excerpt = get_the_excerpt( $post_id );
+				$parent  = get_post( $post->post_parent );
+
+				// Check if the Post is Published.
+				if ( ! empty( $excerpt ) ) {
+					// Check if it's the Home URL
+					if ( true === \WPCOM_Legacy_Redirector::check_if_excerpt_is_home( $excerpt ) ) {
+						echo esc_html( $excerpt );
+					} elseif ( 0 === strpos( $excerpt, 'http' ) ) {
+						echo esc_url_raw( $excerpt );
+					} else {
+						if ( 'private' === \WPCOM_Legacy_Redirector::vip_legacy_redirect_check_if_public( $excerpt ) ) {
+							echo esc_html( $excerpt ) . '<br /><em>' . esc_html__( 'Warning: Redirect is not a public URL.', 'wpcom-legacy-redirector' ) . '</em>';
+						} else {
+							echo esc_html( $excerpt );
+						}
+					}
+				} else {
+					switch ( \WPCOM_Legacy_Redirector::vip_legacy_redirect_parent_id( $post ) ) {
+						case false:
+							echo '<em>' . esc_html__( 'Redirect is pointing to a Post ID that does not exist.', 'wpcom-legacy-redirector' ) . '</em>';
+							break;
+						case 'private':
+							echo ( esc_html( get_permalink( $parent ) ) . '<br /><em>' . esc_html__( 'Warning: Redirect is not a public URL.', 'wpcom-legacy-redirector' ) . '</em>' );
+							break;
+						default:
+							echo esc_html( str_replace( home_url(), '', get_permalink( $parent ) ) );
+					}
+				}
+				break;
+		}
+	}
+
+	/**
+	 * Modify the Row Actions for the vip-legacy-redirect post type.
+	 *
+	 * @param array $actions Default Actions.
+	 * @param object $post the current Post.
+	 */
+	public function modify_list_row_actions( $actions, $post ) {
+		// Check for your post type.
+		if ( Post_Type::POST_TYPE === $post->post_type ) {
+
+			$url = admin_url( 'post.php?post=vip-legacy-redirect&post=' . $post->ID );
+
+			if ( isset( $_GET['post_status'] ) && 'trash' === $_GET['post_status'] ) {
+				return $actions;
+			}
+			$trash   = $actions['trash'];
+			$actions = array();
+
+			if ( current_user_can( 'manage_redirects' ) ) {
+				// Add a nonce to Validate Link
+				$validate_link = wp_nonce_url(
+					add_query_arg(
+						array(
+							'action' => 'validate',
+						),
+						$url
+					),
+					'validate_vip_legacy_redirect',
+					'_validate_redirect'
+				);
+
+				// Add the Validate Link
+				$actions = array_merge(
+					$actions,
+					array(
+						'validate' => sprintf(
+							'<a href="%1$s">%2$s</a>',
+							esc_url( $validate_link ),
+							'Validate'
+						),
+					)
+				);
+				// Re-insert thrash link preserved from the default $actions.
+				$actions['trash'] = $trash;
+			}
+		}
+		return $actions;
+	}
+}

--- a/includes/class-list-redirects.php
+++ b/includes/class-list-redirects.php
@@ -89,7 +89,7 @@ final class List_Redirects {
 			$trash   = $actions['trash'];
 			$actions = array();
 
-			if ( current_user_can( 'manage_redirects' ) ) {
+			if ( current_user_can( Capability::MANAGE_REDIRECTS_CAPABILITY ) ) {
 				// Add a nonce to Validate Link
 				$validate_link = wp_nonce_url(
 					add_query_arg(

--- a/includes/class-lookup.php
+++ b/includes/class-lookup.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Automattic\LegacyRedirector;
+
+final class Lookup {
+	const CACHE_GROUP = 'vip-legacy-redirect-2';
+
+	/**
+	 * Get Redirect Destination URL.
+	 *
+	 * @param string $url URL to redirect (source).
+	 * @return string|bool Redirect URL if one was found; otherwise false.
+	 */
+	static function get_redirect_uri( $url ) {
+		$url = \WPCOM_Legacy_Redirector::normalise_url( $url );
+		if ( is_wp_error( $url ) ) {
+			return false;
+		}
+
+		$preservable_params = self::get_preservable_querystring_params_from_url( $url );
+
+		$url = remove_query_arg( array_keys( $preservable_params ), $url );
+
+		$url_hash = \WPCOM_Legacy_Redirector::get_url_hash( $url );
+
+		$redirect_post_id = wp_cache_get( $url_hash, self::CACHE_GROUP );
+
+		if ( false === $redirect_post_id ) {
+			$redirect_post_id = self::get_redirect_post_id( $url );
+			wp_cache_add( $url_hash, $redirect_post_id, self::CACHE_GROUP );
+		}
+
+		if ( $redirect_post_id ) {
+			$redirect_post = get_post( $redirect_post_id );
+			if ( ! $redirect_post instanceof \WP_Post ) {
+				// If redirect post object doesn't exist, reset cache.
+				wp_cache_set( $url_hash, 0, self::CACHE_GROUP );
+
+				return false;
+			} elseif ( 0 !== $redirect_post->post_parent ) {
+				// Add preserved params to the destination URL.
+				return add_query_arg( $preservable_params, get_permalink( $redirect_post->post_parent ) );
+			} elseif ( ! empty( $redirect_post->post_excerpt ) ) {
+				// Add preserved params to the destination URL.
+				return add_query_arg( $preservable_params, esc_url_raw( $redirect_post->post_excerpt ) );
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get the preservable query string parameters from a given URL.
+	 *
+	 * Does not edit the URL.
+	 *
+	 * @throws \UnexpectedValueException Invalid value from filter.
+	 *
+	 * @param string $url Normalized source URL with or without querystring.
+	 * @return array Associative array of preserved keys and values that were stripped.
+	 */
+	public static function get_preservable_querystring_params_from_url( $url ) {
+		/**
+		 * Filter the list of preservable querystring parameter keys.
+		 *
+		 * The plugin supports providing a list of querystring keys that should be ignored
+		 * when calculating the URL hash. These keys and their values are stripped, the
+		 * redirect lookup is done on the remaining URL, and then the keys and values are appended
+		 * to the destination URL.
+		 *
+		 * Note that if you amend this list after URLs that include the preserved keys have been
+		 * saved to the database, then the redirect lookup will fail for those URLs.
+		 *
+		 * @since 1.3.0
+		 *
+		 * @param string[] $preservable_param_keys Indexed array of strings containing the querystring keys
+		 *                                         that should be preserved on the destination URL.
+		 * @param string   $url                    Normalized source URL.
+		 */
+		$preservable_param_keys = apply_filters( 'wpcom_legacy_redirector_preserve_query_params', array(), $url );
+		
+		if ( ! is_array( $preservable_param_keys ) ) {
+			throw new \UnexpectedValueException( 'wpcom_legacy_redirector_preserve_query_params must return an array.' );
+		}
+		if ( ! empty( $preservable_param_keys ) && array_keys( $preservable_param_keys ) !== range( 0, count( $preservable_param_keys ) - 1 ) ) {
+			throw new \UnexpectedValueException( 'wpcom_legacy_redirector_preserve_query_params must return an indexed array.' );
+		}
+
+		$preserved_param_values = array();
+		$preserved_params       = array();
+
+		// Parse URL to get querystring parameters.
+		$url_query_params = wp_parse_url( $url, PHP_URL_QUERY );
+		
+		// No parameters in URL, so return early.
+		if ( empty( $url_query_params ) ) {
+			return array();
+		}
+
+		// Parse querystring parameters to associative array.
+		parse_str( $url_query_params, $url_params );
+
+		// Extract and return the list of preservable keys (and their values).
+		return array_intersect_key( $url_params, array_flip( $preservable_param_keys ) );
+	}
+
+	/**
+	 * Get Redirect Post ID.
+	 *
+	 * @param string $url URL to redirect (source).
+	 * @return string|int Redirect post ID (as string) if one was found; otherwise 0.
+	 */
+	static function get_redirect_post_id( $url ) {
+		global $wpdb;
+
+		$url_hash = \WPCOM_Legacy_Redirector::get_url_hash( $url );
+
+		$redirect_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_name = %s LIMIT 1", Post_Type::POST_TYPE, $url_hash ) );
+
+		if ( ! $redirect_post_id ) {
+			$redirect_post_id = 0;
+		}
+
+		return $redirect_post_id;
+	}
+
+}

--- a/includes/class-post-type.php
+++ b/includes/class-post-type.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Automattic\LegacyRedirector;
+
+final class Post_Type {
+	const POST_TYPE = 'vip-legacy-redirect';
+
+	public function register() {
+		register_post_type( self::POST_TYPE, $this->get_args() );
+	}
+
+	protected function get_labels() {
+		return array(
+			'name'                  => _x( 'Redirect Manager', 'Post type general name', 'wpcom-legacy-redirector' ),
+			'singular_name'         => _x( 'Redirect Manager', 'Post type singular name', 'wpcom-legacy-redirector' ),
+			'menu_name'             => _x( 'Redirect Manager', 'Admin Menu text', 'wpcom-legacy-redirector' ),
+			'name_admin_bar'        => _x( 'Redirect Manager', 'Add New on Toolbar', 'wpcom-legacy-redirector' ),
+			'add_new'               => __( 'Add New', 'wpcom-legacy-redirector' ),
+			'add_new_item'          => __( 'Add New Redirect', 'wpcom-legacy-redirector' ),
+			'new_item'              => __( 'New Redirect', 'wpcom-legacy-redirector' ),
+			'all_items'             => __( 'All Redirects', 'wpcom-legacy-redirector' ),
+			'search_items'          => __( 'Search Redirects', 'wpcom-legacy-redirector' ),
+			'not_found'             => __( 'No redirects found.', 'wpcom-legacy-redirector' ),
+			'not_found_in_trash'    => __( 'No redirects found in Trash.', 'wpcom-legacy-redirector' ),
+			'filter_items_list'     => _x( 'Filter redirects list', 'Screen reader text for the filter links heading on the post type listing screen. Default “Filter posts list”/”Filter pages list”. Added in 4.4', 'wpcom-legacy-redirector' ),
+			'items_list_navigation' => _x( 'Redirect list navigation', 'Screen reader text for the pagination heading on the post type listing screen. Default “Posts list navigation”/”Pages list navigation”. Added in 4.4', 'wpcom-legacy-redirector' ),
+			'items_list'            => _x( 'Redirects list', 'Screen reader text for the items list heading on the post type listing screen. Default “Posts list”/”Pages list”. Added in 4.4', 'wpcom-legacy-redirector' ),
+		);
+	}
+
+	protected function get_args() {
+		return array(
+			'labels'             => $this->get_labels(),
+			'public'             => false,
+			'publicly_queryable' => true,
+			'show_ui'            => true,
+			'rewrite'            => false,
+			'query_var'          => false,
+			'capability_type'    => 'post',
+			'hierarchical'       => false,
+			'menu_position'      => 100,
+			'show_in_nav_menus'  => false,
+			'show_in_rest'       => false,
+			'capabilities'       => array( 'create_posts' => 'do_not_allow' ),
+			'map_meta_cap'       => true,
+			'menu_icon'          => 'dashicons-randomize',
+			'supports'           => array( 'page-attributes' ),
+		);
+	}
+}

--- a/includes/class-wpcom-legacy-redirector-cli.php
+++ b/includes/class-wpcom-legacy-redirector-cli.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Automattic\LegacyRedirector\Post_Type;
+
 /**
  * Manage redirects added via the WPCOM Legacy Redirector plugin.
  */
@@ -20,7 +22,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 		$total_redirects = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT( ID ) FROM $wpdb->posts WHERE post_type = %s AND post_excerpt LIKE %s",
-				WPCOM_Legacy_Redirector::POST_TYPE,
+				Post_Type::POST_TYPE,
 				'http%'
 			)
 		);
@@ -30,7 +32,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			$redirect_urls = $wpdb->get_col(
 				$wpdb->prepare(
 					"SELECT post_excerpt FROM $wpdb->posts WHERE post_type = %s AND post_excerpt LIKE %s ORDER BY ID ASC LIMIT %d, %d",
-					WPCOM_Legacy_Redirector::POST_TYPE,
+					Post_Type::POST_TYPE,
 					'http%',
 					( $paged * $posts_per_page ),
 					$posts_per_page
@@ -346,7 +348,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 
 		$posts_per_page = 100;
 		$paged          = 1;
-		$post_count     = array_sum( (array) wp_count_posts( WPCOM_Legacy_Redirector::POST_TYPE ) );
+		$post_count     = array_sum( (array) wp_count_posts( Post_Type::POST_TYPE ) );
 		$progress       = \WP_CLI\Utils\make_progress_bar( 'Exporting ' . number_format( $post_count ) . ' redirects', $post_count );
 		$output         = array();
 
@@ -354,7 +356,7 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			$posts = get_posts( array(
 				'posts_per_page'   => $posts_per_page,
 				'paged'            => $paged,
-				'post_type'        => WPCOM_Legacy_Redirector::POST_TYPE,
+				'post_type'        => Post_Type::POST_TYPE,
 				'post_status'      => 'any',
 				'suppress_filters' => 'false',
 			) );

--- a/includes/class-wpcom-legacy-redirector-ui.php
+++ b/includes/class-wpcom-legacy-redirector-ui.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Automattic\LegacyRedirector\Post_Type;
+
 class WPCOM_Legacy_Redirector_UI {
 	/**
 	 * Constructor Class.
@@ -18,7 +20,7 @@ class WPCOM_Legacy_Redirector_UI {
 	 */
 	public function admin_menu() {
 		add_submenu_page(
-			'edit.php?post_type=vip-legacy-redirect',
+			'edit.php?post_type=' . Post_Type::POST_TYPE,
 			__( 'Add Redirect', 'wpcom-legacy-redirector' ),
 			__( 'Add Redirect', 'wpcom-legacy-redirector' ),
 			'manage_redirects',
@@ -133,7 +135,7 @@ class WPCOM_Legacy_Redirector_UI {
 	 */
 	public function modify_list_row_actions( $actions, $post ) {
 		// Check for your post type.
-		if ( 'vip-legacy-redirect' === $post->post_type ) {
+		if ( PostType::POST_TYPE === $post->post_type ) {
 
 			$url = admin_url( 'post.php?post=vip-legacy-redirect&post=' . $post->ID );
 

--- a/includes/class-wpcom-legacy-redirector-ui.php
+++ b/includes/class-wpcom-legacy-redirector-ui.php
@@ -8,10 +8,7 @@ class WPCOM_Legacy_Redirector_UI {
 	 */
 	public function __construct() {
 		add_action( 'admin_notices', array( $this, 'validate_redirects_notices' ), 10, 2 );
-		add_action( 'manage_vip-legacy-redirect_posts_custom_column', array( $this, 'custom_vip_legacy_redirect_column' ), 10, 2 );
 		add_action( 'after_setup_theme', array( $this, 'validate_vip_legacy_redirect' ), 10, 2 );
-		add_filter( 'manage_vip-legacy-redirect_posts_columns', array( $this, 'set_vip_legacy_redirects_columns' ) );
-		add_filter( 'post_row_actions', array( $this, 'modify_list_row_actions' ), 10, 2 );
 		add_filter( 'removable_query_args', array( $this, 'add_removable_arg' ) );
 		add_filter( 'views_edit-vip-legacy-redirect', array( $this, 'vip_redirects_custom_post_status_filters' ) );
 	}
@@ -61,19 +58,7 @@ class WPCOM_Legacy_Redirector_UI {
 			}
 		}
 	}
-	/**
-	 * Set Columns for Redirect Table.
-	 *
-	 * @param array $columns Columns to show for the post type.
-	 */
-	public function set_vip_legacy_redirects_columns( $columns ) {
-		return array(
-			'cb'   => '<input type="checkbox" />',
-			'from' => __( 'Redirect From' ),
-			'to'   => __( 'Redirect To' ),
-			'date' => __( 'Date' ),
-		);
-	}
+
 	/**
 	 * Remove "draft" from the status filters for vip-legacy-redirect post type.
 	 */
@@ -81,100 +66,8 @@ class WPCOM_Legacy_Redirector_UI {
 		unset( $views['draft'] );
 		return $views;
 	}
-	/**
-	 * Add the data to the custom columns for the vip-legacy-redirects post type.
-	 * Provide warnings for possibly bad redirects.
-	 *
-	 * @param string $column The Column for the post_type table.
-	 * @param int $post_id  The Post ID.
-	 */
-	public function custom_vip_legacy_redirect_column( $column, $post_id ) {
-		switch ( $column ) {
-			case 'from':
-				echo esc_html( get_the_title( $post_id ) );
-				break;
-			case 'to':
-				$post    = get_post( $post_id );
-				$excerpt = get_the_excerpt( $post_id );
-				$parent  = get_post( $post->post_parent );
-
-				// Check if the Post is Published.
-				if ( ! empty( $excerpt ) ) {
-					// Check if it's the Home URL
-					if ( true === WPCOM_Legacy_Redirector::check_if_excerpt_is_home( $excerpt ) ) {
-						echo esc_html( $excerpt );
-					} elseif ( 0 === strpos( $excerpt, 'http' ) ) {
-						echo esc_url_raw( $excerpt );
-					} else {
-						if ( 'private' === WPCOM_Legacy_Redirector::vip_legacy_redirect_check_if_public( $excerpt ) ) {
-							echo esc_html( $excerpt ) . '<br /><em>' . esc_html__( 'Warning: Redirect is not a public URL.', 'wpcom-legacy-redirector' ) . '</em>';
-						} else {
-							echo esc_html( $excerpt );
-						}
-					}
-				} else {
-					switch ( WPCOM_Legacy_Redirector::vip_legacy_redirect_parent_id( $post ) ) {
-						case false:
-							echo '<em>' . esc_html__( 'Redirect is pointing to a Post ID that does not exist.', 'wpcom-legacy-redirector' ) . '</em>';
-							break;
-						case 'private':
-							echo ( esc_html( get_permalink( $parent ) ) . '<br /><em>' . esc_html__( 'Warning: Redirect is not a public URL.', 'wpcom-legacy-redirector' ) . '</em>' );
-							break;
-						default:
-							echo esc_html( str_replace( home_url(), '', get_permalink( $parent ) ) );
-					}
-				}
-				break;
-		}
-	}
-	/**
-	 * Modify the Row Actions for the vip-legacy-redirect post type.
-	 *
-	 * @param array $actions Default Actions.
-	 * @param object $post the current Post.
-	 */
-	public function modify_list_row_actions( $actions, $post ) {
-		// Check for your post type.
-		if ( PostType::POST_TYPE === $post->post_type ) {
-
-			$url = admin_url( 'post.php?post=vip-legacy-redirect&post=' . $post->ID );
-
-			if ( isset( $_GET['post_status'] ) && 'trash' === $_GET['post_status'] ) {
-				return $actions;
-			}
-			$trash   = $actions['trash'];
-			$actions = array();
-
-			if ( current_user_can( 'manage_redirects' ) ) {
-				// Add a nonce to Validate Link
-				$validate_link = wp_nonce_url(
-					add_query_arg(
-						array(
-							'action' => 'validate',
-						),
-						$url
-					),
-					'validate_vip_legacy_redirect',
-					'_validate_redirect'
-				);
-
-				// Add the Validate Link
-				$actions = array_merge(
-					$actions,
-					array(
-						'validate' => sprintf(
-							'<a href="%1$s">%2$s</a>',
-							esc_url( $validate_link ),
-							'Validate'
-						),
-					)
-				);
-				// Re-insert thrash link preserved from the default $actions.
-				$actions['trash'] = $trash;
-			}
-		}
-		return $actions;
-	}
+	
+	
 	/**
 	 * Return error data when validate check fails.
 	 *

--- a/includes/class-wpcom-legacy-redirector-ui.php
+++ b/includes/class-wpcom-legacy-redirector-ui.php
@@ -1,5 +1,6 @@
 <?php
 
+use \Automattic\LegacyRedirector\Capability;
 use \Automattic\LegacyRedirector\Post_Type;
 
 class WPCOM_Legacy_Redirector_UI {
@@ -20,7 +21,7 @@ class WPCOM_Legacy_Redirector_UI {
 			'edit.php?post_type=' . Post_Type::POST_TYPE,
 			__( 'Add Redirect', 'wpcom-legacy-redirector' ),
 			__( 'Add Redirect', 'wpcom-legacy-redirector' ),
-			'manage_redirects',
+			Capability::MANAGE_REDIRECTS_CAPABILITY,
 			'wpcom-legacy-redirector',
 			array( $this, 'generate_page_html' )
 		);
@@ -127,7 +128,7 @@ class WPCOM_Legacy_Redirector_UI {
 	 * Validate the redirect that is being added.
 	 */
 	public function add_redirect_validation() {
-		if ( ! current_user_can( 'manage_redirects' ) ) {
+		if ( ! current_user_can( Capability::MANAGE_REDIRECTS_CAPABILITY ) ) {
 			return;
 		}
 		$errors   = array();

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -1,7 +1,8 @@
 <?php
 
-use \Automattic\LegacyRedirector\Post_Type;
+use \Automattic\LegacyRedirector\Capability;
 use \Automattic\LegacyRedirector\List_Redirects;
+use \Automattic\LegacyRedirector\Post_Type;
 
 /**
  * Plugin core functionality for creating, validating, and performing redirect rules.
@@ -16,7 +17,6 @@ class WPCOM_Legacy_Redirector {
 	 */
 	static function start() {
 		add_action( 'init', array( __CLASS__, 'init' ) );
-		add_action( 'init', array( __CLASS__, 'register_redirect_custom_capability' ) );
 		add_filter( 'template_redirect', array( __CLASS__, 'maybe_do_redirect' ), 0 ); // hook in early, before the canonical redirect.
 		add_action( 'admin_menu', array( new WPCOM_Legacy_Redirector_UI(), 'admin_menu' ) );
 		add_filter( 'admin_enqueue_scripts', array( __CLASS__, 'wpcom_legacy_add_redirect_js' ) );
@@ -30,25 +30,11 @@ class WPCOM_Legacy_Redirector {
 		$post_type = new Post_Type();
 		$post_type->register();
 
+		$capability = new Capability();
+		$capability->register();
+
 		$list_redirects = new List_Redirects();
 		$list_redirects->init();
-	}
-
-	/**
-	 * Register custom role using VIP Helpers with fallbacks.
-	 */
-	static function register_redirect_custom_capability() {
-		$cap = apply_filters( 'manage_redirect_capability', 'manage_redirects' );
-		if ( function_exists( 'wpcom_vip_add_role_caps' ) ) {
-			wpcom_vip_add_role_caps( 'administrator', $cap );
-			wpcom_vip_add_role_caps( 'editor', $cap );
-		} else {
-			$roles = array( 'administrator', 'editor' );
-			foreach ( $roles as $role ) {
-				$role_obj = get_role( $role );
-				$role_obj->add_cap( $cap );
-			}
-		}
 	}
 
 	/**

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -29,6 +29,9 @@ class WPCOM_Legacy_Redirector {
 	static function init() {
 		$post_type = new Post_Type();
 		$post_type->register();
+
+		$list_redirects = new List_Redirects();
+		$list_redirects->init();
 	}
 
 	/**

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -1,9 +1,13 @@
 <?php
 
+use \Automattic\LegacyRedirector\Post_Type;
+use \Automattic\LegacyRedirector\List_Redirects;
+
 /**
  * Plugin core functionality for creating, validating, and performing redirect rules.
  */
 class WPCOM_Legacy_Redirector {
+	// Deprecated. Use \Automattic\LegacyRedirector\Post_Type::POST_TYPE instead.
 	const POST_TYPE   = 'vip-legacy-redirect';
 	const CACHE_GROUP = 'vip-legacy-redirect-2';
 
@@ -16,48 +20,15 @@ class WPCOM_Legacy_Redirector {
 		add_filter( 'template_redirect', array( __CLASS__, 'maybe_do_redirect' ), 0 ); // hook in early, before the canonical redirect.
 		add_action( 'admin_menu', array( new WPCOM_Legacy_Redirector_UI(), 'admin_menu' ) );
 		add_filter( 'admin_enqueue_scripts', array( __CLASS__, 'wpcom_legacy_add_redirect_js' ) );
-		add_filter( 'bulk_actions-edit-' . self::POST_TYPE, array( __CLASS__, 'remove_bulk_edit' ) );
+		add_filter( 'bulk_actions-edit-' . Post_Type::POST_TYPE, array( __CLASS__, 'remove_bulk_edit' ) );
 	}
 
 	/**
-	 * Initialize and register the CPT.
+	 * Initialize and register other classes.
 	 */
 	static function init() {
-		$labels = array(
-			'name'                  => _x( 'Redirect Manager', 'Post type general name', 'wpcom-legacy-redirector' ),
-			'singular_name'         => _x( 'Redirect Manager', 'Post type singular name', 'wpcom-legacy-redirector' ),
-			'menu_name'             => _x( 'Redirect Manager', 'Admin Menu text', 'wpcom-legacy-redirector' ),
-			'name_admin_bar'        => _x( 'Redirect Manager', 'Add New on Toolbar', 'wpcom-legacy-redirector' ),
-			'add_new'               => __( 'Add New', 'wpcom-legacy-redirector' ),
-			'add_new_item'          => __( 'Add New Redirect', 'wpcom-legacy-redirector' ),
-			'new_item'              => __( 'New Redirect', 'wpcom-legacy-redirector' ),
-			'all_items'             => __( 'All Redirects', 'wpcom-legacy-redirector' ),
-			'search_items'          => __( 'Search Redirects', 'wpcom-legacy-redirector' ),
-			'not_found'             => __( 'No redirects found.', 'wpcom-legacy-redirector' ),
-			'not_found_in_trash'    => __( 'No redirects found in Trash.', 'wpcom-legacy-redirector' ),
-			'filter_items_list'     => _x( 'Filter redirects list', 'Screen reader text for the filter links heading on the post type listing screen. Default “Filter posts list”/”Filter pages list”. Added in 4.4', 'wpcom-legacy-redirector' ),
-			'items_list_navigation' => _x( 'Redirect list navigation', 'Screen reader text for the pagination heading on the post type listing screen. Default “Posts list navigation”/”Pages list navigation”. Added in 4.4', 'wpcom-legacy-redirector' ),
-			'items_list'            => _x( 'Redirects list', 'Screen reader text for the items list heading on the post type listing screen. Default “Posts list”/”Pages list”. Added in 4.4', 'wpcom-legacy-redirector' ),
-		);
-
-		$args = array(
-			'labels'             => $labels,
-			'public'             => false,
-			'publicly_queryable' => true,
-			'show_ui'            => true,
-			'rewrite'            => false,
-			'query_var'          => false,
-			'capability_type'    => 'post',
-			'hierarchical'       => false,
-			'menu_position'      => 100,
-			'show_in_nav_menus'  => false,
-			'show_in_rest'       => false,
-			'capabilities'       => array( 'create_posts' => 'do_not_allow' ),
-			'map_meta_cap'       => true,
-			'menu_icon'          => 'dashicons-randomize',
-			'supports'           => [ 'page-attributes' ],
-		);
-		register_post_type( self::POST_TYPE, $args );
+		$post_type = new Post_Type();
+		$post_type->register();
 	}
 
 	/**
@@ -173,7 +144,7 @@ class WPCOM_Legacy_Redirector {
 		$args = array(
 			'post_name'  => $from_url_hash,
 			'post_title' => $from_url,
-			'post_type'  => self::POST_TYPE,
+			'post_type'  => Post_Type::POST_TYPE,
 		);
 
 		if ( is_numeric( $redirect_to ) ) {
@@ -346,7 +317,7 @@ class WPCOM_Legacy_Redirector {
 
 		$url_hash = self::get_url_hash( $url );
 
-		$redirect_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_name = %s LIMIT 1", self::POST_TYPE, $url_hash ) );
+		$redirect_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_name = %s LIMIT 1", Post_Type::POST_TYPE, $url_hash ) );
 
 		if ( ! $redirect_post_id ) {
 			$redirect_post_id = 0;

--- a/includes/class-wpcom-legacy-redirector.php
+++ b/includes/class-wpcom-legacy-redirector.php
@@ -2,6 +2,7 @@
 
 use \Automattic\LegacyRedirector\Capability;
 use \Automattic\LegacyRedirector\List_Redirects;
+use \Automattic\LegacyRedirector\Lookup;
 use \Automattic\LegacyRedirector\Post_Type;
 
 /**
@@ -67,7 +68,7 @@ class WPCOM_Legacy_Redirector {
 		$request_path = apply_filters( 'wpcom_legacy_redirector_request_path', $url );
 
 		if ( $request_path ) {
-			$redirect_uri = self::get_redirect_uri( $request_path );
+			$redirect_uri = Lookup::get_redirect_uri( $request_path );
 			if ( $redirect_uri ) {
 				$redirect_status = apply_filters( 'wpcom_legacy_redirector_redirect_status', 301, $url );
 
@@ -159,7 +160,7 @@ class WPCOM_Legacy_Redirector {
 	 * @return array|WP_Error Error if invalid redirect URL specified; returns array of params otherwise.
 	 */
 	static function validate_urls( $from_url, $redirect_to ) {
-		if ( false !== self::get_redirect_uri( $from_url ) ) {
+		if ( false !== Lookup::get_redirect_uri( $from_url ) ) {
 			return new WP_Error( 'duplicate-redirect-uri', 'A redirect for this URI already exists' );
 		}
 		if ( is_numeric( $redirect_to ) || false !== strpos( $redirect_to, 'http' ) ) {
@@ -197,131 +198,12 @@ class WPCOM_Legacy_Redirector {
 	}
 
 	/**
-	 * Get the preservable query string parameters from a given URL.
-	 *
-	 * Does not edit the URL.
-	 *
-	 * @throws \UnexpectedValueException Invalid value from filter.
-	 *
-	 * @param string $url Normalized source URL with or without querystring.
-	 * @return array Associative array of preserved keys and values that were stripped.
-	 */
-	public static function get_preservable_querystring_params_from_url( $url ) {
-		/**
-		 * Filter the list of preservable querystring parameter keys.
-		 *
-		 * The plugin supports providing a list of querystring keys that should be ignored
-		 * when calculating the URL hash. These keys and their values are stripped, the
-		 * redirect lookup is done on the remaining URL, and then the keys and values are appended
-		 * to the destination URL.
-		 *
-		 * Note that if you amend this list after URLs that include the preserved keys have been
-		 * saved to the database, then the redirect lookup will fail for those URLs.
-		 *
-		 * @since 1.3.0
-		 *
-		 * @param string[] $preservable_param_keys Indexed array of strings containing the querystring keys
-		 *                                         that should be preserved on the destination URL.
-		 * @param string   $url                    Normalized source URL.
-		 */
-		$preservable_param_keys = apply_filters( 'wpcom_legacy_redirector_preserve_query_params', array(), $url );
-		
-		if ( ! is_array( $preservable_param_keys ) ) {
-			throw new \UnexpectedValueException( 'wpcom_legacy_redirector_preserve_query_params must return an array.' );
-		}
-		if ( ! empty( $preservable_param_keys ) && array_keys( $preservable_param_keys ) !== range( 0, count( $preservable_param_keys ) - 1 ) ) {
-			throw new \UnexpectedValueException( 'wpcom_legacy_redirector_preserve_query_params must return an indexed array.' );
-		}
-
-		$preserved_param_values = array();
-		$preserved_params       = array();
-
-		// Parse URL to get querystring parameters.
-		$url_query_params = wp_parse_url( $url, PHP_URL_QUERY );
-		
-		// No parameters in URL, so return early.
-		if ( empty( $url_query_params ) ) {
-			return array();
-		}
-
-		// Parse querystring parameters to associative array.
-		parse_str( $url_query_params, $url_params );
-
-		// Extract and return the list of preservable keys (and their values).
-		return array_intersect_key( $url_params, array_flip( $preservable_param_keys ) );
-	}
-
-	/**
-	 * Get Redirect Destination URL.
-	 *
-	 * @param string $url URL to redirect (source).
-	 * @return string|bool Redirect URL if one was found; otherwise false.
-	 */
-	static function get_redirect_uri( $url ) {
-		$url = self::normalise_url( $url );
-		if ( is_wp_error( $url ) ) {
-			return false;
-		}
-
-		$preservable_params = self::get_preservable_querystring_params_from_url( $url );
-
-		$url = remove_query_arg( array_keys( $preservable_params ), $url );
-
-		$url_hash = self::get_url_hash( $url );
-
-		$redirect_post_id = wp_cache_get( $url_hash, self::CACHE_GROUP );
-
-		if ( false === $redirect_post_id ) {
-			$redirect_post_id = self::get_redirect_post_id( $url );
-			wp_cache_add( $url_hash, $redirect_post_id, self::CACHE_GROUP );
-		}
-
-		if ( $redirect_post_id ) {
-			$redirect_post = get_post( $redirect_post_id );
-			if ( ! $redirect_post instanceof WP_Post ) {
-				// If redirect post object doesn't exist, reset cache.
-				wp_cache_set( $url_hash, 0, self::CACHE_GROUP );
-
-				return false;
-			} elseif ( 0 !== $redirect_post->post_parent ) {
-				// Add preserved params to the destination URL.
-				return add_query_arg( $preservable_params, get_permalink( $redirect_post->post_parent ) );
-			} elseif ( ! empty( $redirect_post->post_excerpt ) ) {
-				// Add preserved params to the destination URL.
-				return add_query_arg( $preservable_params, esc_url_raw( $redirect_post->post_excerpt ) );
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Get Redirect Post ID.
-	 *
-	 * @param string $url URL to redirect (source).
-	 * @return string|int Redirect post ID (as string) if one was found; otherwise 0.
-	 */
-	static function get_redirect_post_id( $url ) {
-		global $wpdb;
-
-		$url_hash = self::get_url_hash( $url );
-
-		$redirect_post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_name = %s LIMIT 1", Post_Type::POST_TYPE, $url_hash ) );
-
-		if ( ! $redirect_post_id ) {
-			$redirect_post_id = 0;
-		}
-
-		return $redirect_post_id;
-	}
-
-	/**
 	 * Utility to get MD5 hash of URL.
 	 *
 	 * @param string $url URL to hash.
 	 * @return string Hash representation of string.
 	 */
-	private static function get_url_hash( $url ) {
+	public static function get_url_hash( $url ) {
 		return md5( $url );
 	}
 
@@ -332,7 +214,7 @@ class WPCOM_Legacy_Redirector {
 	 * @param string $url URL to transform.
 	 * @return string|WP_Error Transformed URL; error if validation failed.
 	 */
-	private static function normalise_url( $url ) {
+	public static function normalise_url( $url ) {
 		// Sanitise the URL first rather than trying to normalise a non-URL.
 		$url = esc_url_raw( $url );
 		if ( empty( $url ) ) {

--- a/tests/integration/PostTypeTest.php
+++ b/tests/integration/PostTypeTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Automattic\LegacyRedirector\Tests;
+
+use Automattic\LegacyRedirector\Post_Type;
+
+class PostTypeTest extends TestCase {
+	public function test_post_type_is_registered() {
+		$this->assertTrue( post_type_exists( Post_Type::POST_TYPE ) );
+	}
+}

--- a/tests/integration/RedirectsTest.php
+++ b/tests/integration/RedirectsTest.php
@@ -37,7 +37,7 @@ class RedirectsTest extends TestCase {
 		$redirect = \WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to, false );
 		$this->assertTrue( $redirect, 'insert_legacy_redirect failed' );
 
-		$redirect = \WPCOM_Legacy_Redirector::get_redirect_uri( $from );
+		$redirect = \Automattic\LegacyRedirector\Lookup::get_redirect_uri( $from );
 		$this->assertEquals( $redirect, $to, 'get_redirect_uri failed' );
 	}
 
@@ -102,7 +102,7 @@ class RedirectsTest extends TestCase {
 		$redirect = \WPCOM_Legacy_Redirector::insert_legacy_redirect( $from, $to, false );
 		$this->assertTrue( $redirect, 'insert_legacy_redirect failed' );
 
-		$redirect = \WPCOM_Legacy_Redirector::get_redirect_uri( $protected_from );
+		$redirect = \Automattic\LegacyRedirector\Lookup::get_redirect_uri( $protected_from );
 		$this->assertEquals( $redirect, $protected_to, 'get_redirect_uri failed' );
 	}
 

--- a/tests/unit/PreservableParamsTest.php
+++ b/tests/unit/PreservableParamsTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\LegacyRedirector\Tests;
 
+use Automattic\LegacyRedirector\Lookup;
 use Brain\Monkey;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
@@ -104,7 +105,7 @@ class PreservableParamsTest extends TestCase {
 			$this->expectException( \get_class( $expected ) );
 		}
 
-		$actual = \WPCOM_Legacy_Redirector::get_preservable_querystring_params_from_url( $url );
+		$actual = Lookup::get_preservable_querystring_params_from_url( $url );
 
 		$this->assertSame( $expected, $actual, 'Preserved keys and values do not match.' );
 	}

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -32,6 +32,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 require __DIR__ . '/includes/class-capability.php';
 require __DIR__ . '/includes/class-post-type.php';
 require __DIR__ . '/includes/class-list-redirects.php';
+require __DIR__ . '/includes/class-lookup.php';
 require __DIR__ . '/includes/class-wpcom-legacy-redirector-ui.php';
 require __DIR__ . '/includes/class-wpcom-legacy-redirector.php';
 

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -29,6 +29,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	WP_CLI::add_command( 'wpcom-legacy-redirector', 'WPCOM_Legacy_Redirector_CLI' );
 }
 
+require __DIR__ . '/includes/class-post-type.php';
+require __DIR__ . '/includes/class-list-redirects.php';
 require __DIR__ . '/includes/class-wpcom-legacy-redirector-ui.php';
 require __DIR__ . '/includes/class-wpcom-legacy-redirector.php';
 

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -29,6 +29,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	WP_CLI::add_command( 'wpcom-legacy-redirector', 'WPCOM_Legacy_Redirector_CLI' );
 }
 
+require __DIR__ . '/includes/class-capability.php';
 require __DIR__ . '/includes/class-post-type.php';
 require __DIR__ . '/includes/class-list-redirects.php';
 require __DIR__ . '/includes/class-wpcom-legacy-redirector-ui.php';


### PR DESCRIPTION
Viewing the commits individually makes it easier to see the changes.

- **Extract post type registration to class**
  Moves the registration of the post type, and the definitive constant holding the name of the post type, to a new class.

  The previous constant is maintained, and will be removed in a breaking-change release.

  The instantiation is kept within the static `init` method, but may be moved later.
- **Extract redirects list UI to class**
  Moves the methods that amend the redirects list to a new class.
- **Extract capability handling to class**
  Moves the methods that define the name of a new capability and assign it to two existing roles to a new class.
- **Extract lookup handling to class**
  Moves the methods that do the URL lookup to a new class. This will likely change again in the future, but gets it out of the main class.

There is no change to logic in these, just class method and constant references.

The goal would to be ultimately get rid of the "main" class, or just leave it as the composition root / controller.