### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           # Check lowest supported WP version, with the lowest supported PHP.
-          - wordpress: '5.9'
+          - wordpress: '6.4'
             php: '7.4'
             allowed_failure: false
           # Check latest WP with the highest supported PHP.

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://github.com/Automattic/WPCOM-Legacy-Redirector
  * Description: Simple plugin for handling legacy redirects in a scalable manner.
  * Version: 1.4.0-alpha
+ * Requires at least: 6.4
  * Requires PHP: 7.4
  * Author: Automattic / WordPress VIP
  * Author URI: https://wpvip.com


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.