### PR TITLE
Autoloader fallback without composer

### DIFF
--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -41,17 +41,19 @@ const VERSION     = '2.0.0-alpha';
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 } else {
-	spl_autoload_register( function ( string $class ): void {
-		$prefix = 'Automattic\\LegacyRedirector\\';
-		if ( ! str_starts_with( $class, $prefix ) ) {
-			return;
+	spl_autoload_register(
+		function ( string $class_name ): void {
+			$prefix = 'Automattic\\LegacyRedirector\\';
+			if ( ! str_starts_with( $class_name, $prefix ) ) {
+				return;
+			}
+			$relative = substr( $class_name, strlen( $prefix ) );
+			$file     = __DIR__ . '/src/' . str_replace( '\\', '/', $relative ) . '.php';
+			if ( file_exists( $file ) ) {
+				require_once $file;
+			}
 		}
-		$relative = substr( $class, strlen( $prefix ) );
-		$file     = __DIR__ . '/src/' . str_replace( '\\', '/', $relative ) . '.php';
-		if ( file_exists( $file ) ) {
-			require_once $file;
-		}
-	} );
+	);
 }
 
 // Initialize the plugin.

--- a/wpcom-legacy-redirector.php
+++ b/wpcom-legacy-redirector.php
@@ -37,9 +37,21 @@ const VERSION     = '2.0.0-alpha';
 \define( 'WPCOM_LEGACY_REDIRECTOR_FILE', __FILE__ );
 \define( 'WPCOM_LEGACY_REDIRECTOR_VERSION', VERSION );
 
-// Load Composer autoloader for PSR-4 classes (src/).
+// Load Composer autoloader for PSR-4 classes (src/), or register a simple fallback.
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
+} else {
+	spl_autoload_register( function ( string $class ): void {
+		$prefix = 'Automattic\\LegacyRedirector\\';
+		if ( ! str_starts_with( $class, $prefix ) ) {
+			return;
+		}
+		$relative = substr( $class, strlen( $prefix ) );
+		$file     = __DIR__ . '/src/' . str_replace( '\\', '/', $relative ) . '.php';
+		if ( file_exists( $file ) ) {
+			require_once $file;
+		}
+	} );
 }
 
 // Initialize the plugin.


### PR DESCRIPTION
The plugin uses PSR-4 autoloading to load classes from src/, however, without running composer install none of those classes are available. This PR creates a simple fallback for instances where /vendor/autoload.php file is not available.