### PR TITLE
Fix meta-key parameter in import-from-meta CLI command

### DIFF
--- a/src/Infrastructure/WordPress/Cli/ImportFromMetaCommand.php
+++ b/src/Infrastructure/WordPress/Cli/ImportFromMetaCommand.php
@@ -101,7 +101,7 @@ final class ImportFromMetaCommand extends WP_CLI_Command {
 
 		$offset     = isset( $assoc_args['start'] ) ? intval( $assoc_args['start'] ) : 0;
 		$end_offset = isset( $assoc_args['end'] ) ? intval( $assoc_args['end'] ) : 99999999;
-		$meta_key   = isset( $assoc_args['meta_key'] ) ? sanitize_key( $assoc_args['meta_key'] ) : '';
+		$meta_key   = isset( $assoc_args['meta-key'] ) ? sanitize_key( $assoc_args['meta-key'] ) : '';
 		$skip_dupes = isset( $assoc_args['skip_dupes'] ) ? (bool) intval( $assoc_args['skip_dupes'] ) : false;
 		$format     = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
 		$dry_run    = isset( $assoc_args['dry_run'] );


### PR DESCRIPTION
## Summary

The `import-from-meta` WP-CLI command has been unusable since its parameter name was mismatched between the docblock and the code. The docblock declares `--meta-key` (hyphen), but the code reads `$assoc_args['meta_key']` (underscore). Since WP-CLI normalises parameter names based on the docblock, the value arrives in `$assoc_args` as `meta-key`, meaning the code never finds it and always falls back to an empty string.

This corrects the key to `meta-key` so the command works as documented.

Closes #163

## Test plan

- [ ] Run `wp wpcom-legacy-redirector import-from-meta --meta-key=some-key` and confirm it no longer errors with "No redirects found for meta_key:"